### PR TITLE
fix: news image overflowing

### DIFF
--- a/src/routes/NewsPage/NewsPage.module.css
+++ b/src/routes/NewsPage/NewsPage.module.css
@@ -55,6 +55,10 @@
     text-decoration: underline;
 }
 
+.content img {
+    max-width: 100%;
+}
+
 .info {
     display: grid;
     grid-template-columns: auto auto;


### PR DESCRIPTION
Just to fix that image overflowing on the Engine Presets article