### PR TITLE
Add Graphics API selection in Profile Settings

### DIFF
--- a/src/profiles/actions.ts
+++ b/src/profiles/actions.ts
@@ -8,6 +8,7 @@ import { useDirectories } from "./directories";
 import { showErrorDialog } from "@app/dialogs";
 import { useOfflineStatus } from "@app/hooks/useOfflineStatus";
 import { settingsManager } from "@app/settings";
+import { getApiLaunchArgument } from "@app/utils/graphicsApi";
 
 export const downloadAndInstall = async (profile: ActiveProfile, profilePath: string, onFinish?: () => void): Promise<void> => {
     const directories = useDirectories.getState();
@@ -63,7 +64,7 @@ export const launch = async (activeProfile: ActiveProfile, profilePath: string):
         await invoke("launch_profile", {
             profilePath: profilePath,
             execPath: launchOptions.executablePath,
-            arguments: [...launchOptions.arguments, ...otherArguments, ...customArguments]
+            arguments: [...launchOptions.arguments, getApiLaunchArgument(activeProfile.graphicsApi), ...otherArguments, ...customArguments]
         });
     } catch (e) {
         showErrorDialog(e as string);

--- a/src/profiles/types.ts
+++ b/src/profiles/types.ts
@@ -118,8 +118,19 @@ export interface ActiveProfile {
     selectedVersion?: string,
     launchArguments: string,
 
+    graphicsApi: GraphicsApi,
+
     lastPlayed?: string,
 
     profile: Profile,
     version: Version,
+}
+
+export enum GraphicsApi {
+    Default = "Default",
+    D3D11 = "D3D11",
+    D3D12 = "D3D12",
+    OPEN_GL = "OpenGL",
+    VULKAN = "Vulkan",
+    METAL = "Metal",
 }

--- a/src/utils/graphicsApi.ts
+++ b/src/utils/graphicsApi.ts
@@ -1,0 +1,18 @@
+import { GraphicsApi } from "@app/profiles/types";
+
+export const getApiLaunchArgument = (api: GraphicsApi): string => {
+    switch(api) {
+        case GraphicsApi.Default:
+            return "";
+        case GraphicsApi.D3D11:
+            return "-force-d3d11";
+        case GraphicsApi.D3D12:
+            return "-force-d3d12";
+        case GraphicsApi.OPEN_GL:
+            return "-force-glcore";
+        case GraphicsApi.VULKAN:
+            return "-force-vulkan";
+        case GraphicsApi.METAL:
+            return "-force-metal";
+    }
+};


### PR DESCRIPTION
Adds a dropdown list to choose a Graphics API to launch the game with. The Default option will let Unity decide which API to use.

Windows supports: DirectX 11, DirectX 12, OpenGL and Vulkan
MacOS supports: Metal and Vulkan
Linux supports: OpenGL and Vulkan

The dropdown needs to be styled, I'm not very good at that.
The option which is chosen automatically doesn't work and I don't know why. Needs to be fixed.

![image](https://github.com/user-attachments/assets/5410d064-d7a5-4303-8271-b88a17a39c66)