### PR TITLE
Old version warning and version tag for latest release

### DIFF
--- a/src/dialogs/Dialogs/OldVersionDialog.tsx
+++ b/src/dialogs/Dialogs/OldVersionDialog.tsx
@@ -10,7 +10,7 @@ export class OldVersionDialog extends BaseDialog<Record<string, never>> {
     getInnerContents() {
         return <>
             <p>
-                <strong>You are trying to select an old version of YARG!</strong>
+                <strong>You are trying to select an old version of this application!</strong>
                 &#32;These versions may be missing features, contain bugs and potentially corrupt your game data. Use at your own risk!
             </p>
         </>;

--- a/src/dialogs/Dialogs/OldVersionDialog.tsx
+++ b/src/dialogs/Dialogs/OldVersionDialog.tsx
@@ -1,0 +1,33 @@
+import Button, { ButtonColor } from "@app/components/Button";
+import { BaseDialog } from "./BaseDialog";
+import { closeDialog } from "..";
+
+export class OldVersionDialog extends BaseDialog<Record<string, never>> {
+    constructor(props: Record<string, unknown>) {
+        super(props);
+    }
+
+    getInnerContents() {
+        return <>
+            <p>
+                <strong>You are trying to select an old version of YARG!</strong>
+                &#32;These versions may be missing features, contain bugs and potentially corrupt your game data. Use at your own risk!
+            </p>
+        </>;
+    }
+
+    getTitle() {
+        return <>Old Application Version</>;
+    }
+
+    getButtons() {
+        return <>
+            <Button color={ButtonColor.RED} rounded onClick={() => closeDialog("cancel")}>
+                Cancel
+            </Button>
+            <Button color={ButtonColor.GREEN} rounded onClick={() => closeDialog("okay")}>
+                Okay
+            </Button>
+        </>;
+    }
+}

--- a/src/routes/AppProfile/AppSettings.tsx
+++ b/src/routes/AppProfile/AppSettings.tsx
@@ -70,7 +70,7 @@ const VersionListComp: React.FC<VersionListProps> = ({ activeProfile, selectedVe
                 data-state={selectedVersion === undefined ? "active" : "inactive"}
                 onClick={() => setSelectedVersion(undefined)}>
 
-                <header>Latest Release</header>
+                <header>Latest Release ({versionList.length > 0 ? versionList[0].tag : ""})</header>
                 <div>Recommended</div>
             </div>
             {

--- a/src/routes/AppProfile/AppSettings.tsx
+++ b/src/routes/AppProfile/AppSettings.tsx
@@ -31,7 +31,7 @@ const VersionListComp: React.FC<VersionListProps> = ({ activeProfile, selectedVe
     });
 
     const selectVersion = async (uuid: string, index: number) => {
-        if(index != 0) {
+        if (index !== 0) {
             const versionDialogOutput = await createAndShowDialog(OldVersionDialog);
 
             if (versionDialogOutput === "okay") {
@@ -78,7 +78,7 @@ const VersionListComp: React.FC<VersionListProps> = ({ activeProfile, selectedVe
                     <div
                         data-state={selectedVersion === i.uuid ? "active" : "inactive"}
                         key={i.uuid}
-                        onClick={() => selectVersion(i.uuid, index)}>
+                        onClick={async () => await selectVersion(i.uuid, index)}>
 
                         <header>{i.tag}</header>
                         <div>{distanceFromToday(i.release)}</div>

--- a/src/routes/AppProfile/AppSettings.tsx
+++ b/src/routes/AppProfile/AppSettings.tsx
@@ -8,8 +8,9 @@ import InputBox from "@app/components/InputBox";
 import * as Tabs from "@radix-ui/react-tabs";
 import { useOfflineStatus } from "@app/hooks/useOfflineStatus";
 import { useQuery } from "@tanstack/react-query";
-import { showErrorDialog } from "@app/dialogs";
+import { createAndShowDialog, showErrorDialog } from "@app/dialogs";
 import { distanceFromToday } from "@app/utils/timeFormat";
+import { OldVersionDialog } from "@app/dialogs/Dialogs/OldVersionDialog";
 
 interface VersionListProps {
     activeProfile: ActiveProfile,
@@ -28,6 +29,18 @@ const VersionListComp: React.FC<VersionListProps> = ({ activeProfile, selectedVe
             await fetch((activeProfile.profile.version as VersionInfoList).listUrl)
                 .then(res => res.json())
     });
+
+    const selectVersion = async (uuid: string, index: number) => {
+        if(index != 0) {
+            const versionDialogOutput = await createAndShowDialog(OldVersionDialog);
+
+            if (versionDialogOutput === "okay") {
+                setSelectedVersion(uuid);
+            }   
+        } else {
+            setSelectedVersion(uuid);
+        }
+    };
 
     if (versionListQuery.isLoading) {
         return <span className={styles.centered}>
@@ -61,11 +74,11 @@ const VersionListComp: React.FC<VersionListProps> = ({ activeProfile, selectedVe
                 <div>Recommended</div>
             </div>
             {
-                versionList.map(i =>
+                versionList.map((i, index) =>
                     <div
                         data-state={selectedVersion === i.uuid ? "active" : "inactive"}
                         key={i.uuid}
-                        onClick={() => setSelectedVersion(i.uuid)}>
+                        onClick={() => selectVersion(i.uuid, index)}>
 
                         <header>{i.tag}</header>
                         <div>{distanceFromToday(i.release)}</div>


### PR DESCRIPTION
Displays a dialog warning the user of selecting old versions of YARG. Also puts in brackets the version tag for the "Latest Release" so its obvious what version it is.

![image](https://github.com/user-attachments/assets/61f6cc05-bb0d-4db7-885e-287e24f4452b)
![image](https://github.com/user-attachments/assets/6a3930fd-827f-491c-b16a-931fdc27c9cf)
