### PR TITLE
fix: scope issue in Bazzite/Linux immutable os (issue #50)

### DIFF
--- a/src-tauri/tauri.conf.json5
+++ b/src-tauri/tauri.conf.json5
@@ -46,7 +46,10 @@
         "readFile": true,
         "writeFile": true,
         "removeFile": true,
-        "scope": [ "$APPCONFIG", "$APPCONFIG/*" ]
+        "scope": {
+          "allow":[ "$APPCONFIG", "$APPCONFIG/*", "**"],
+          "requireLiteralLeadingDot":false
+        }
       },
       "process": {
         // Required for changing the download location


### PR DESCRIPTION
This fixes - [https://github.com/YARC-Official/YARC-Launcher/issues/50](https://github.com/YARC-Official/YARC-Launcher/issues/50)

In Bazzite, user config folder is at $HOME/.config.
The path config option **requireLiteralLeadingDot** is by default set to "true" in linux based systems, which requires  scopes to explicitly include "." if required.

Setting requireLiteralLeadingDot to false (default in linux is true), and adding "**" to the scope seems to be the only combination that i managed to get working.

Tested in latest Bazzite