### PR TITLE
Add env variable for releases.yarg.in server URL

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+VITE_RELEASES_SERVER_URL=https://releases.yarg.in

--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
 VITE_RELEASES_SERVER_URL=https://releases.yarg.in
+VITE_NEWS_SERVER_URL=https://raw.githubusercontent.com/YARC-Official/News/master

--- a/src/components/NewsSection/NewsAuthor/index.tsx
+++ b/src/components/NewsSection/NewsAuthor/index.tsx
@@ -1,7 +1,6 @@
 import styles from "./NewsAuthor.module.css";
 import UnknownUserIcon from "@app/assets/Icons/UnknownUser.svg";
 import { AuthorData } from "@app/hooks/useNewsAuthor";
-import { newsBaseURL } from "@app/utils/consts";
 import { Img } from "react-image";
 
 interface Props {
@@ -14,7 +13,7 @@ const NewsAuthor: React.FC<Props> = ({author}: Props) => {
             <Img
                 height={48}
                 alt={`${author.displayName}'s avatar`}
-                src={[`${newsBaseURL}/images/avatars/${author.avatar}`, UnknownUserIcon]}
+                src={[`${import.meta.env.VITE_NEWS_SERVER_URL}/images/avatars/${author.avatar}`, UnknownUserIcon]}
             />
         </div>
         <div className={styles.authorInformation}>

--- a/src/components/NewsSection/NewsEntry/index.tsx
+++ b/src/components/NewsSection/NewsEntry/index.tsx
@@ -5,7 +5,6 @@ import { Link } from "react-router-dom";
 import { Img } from "react-image";
 import UnknownUserIcon from "@app/assets/Icons/UnknownUser.svg";
 import { TimeIcon } from "@app/assets/Icons";
-import { newsBaseURL } from "@app/utils/consts";
 import { useNewsAuthorSettings } from "@app/hooks/useNewsAuthor";
 import { useQueries } from "@tanstack/react-query";
 import { distanceFromToday } from "@app/utils/timeFormat";
@@ -22,7 +21,7 @@ const NewsEntry: React.FC<Props> = ({ article }: Props) => {
 
     return <Link to={`/news/${article.md}`} key={article.md} style={{ width: "100%" }}>
         <div className={styles.container}>
-            <img className={styles.thumbnail} src={`${newsBaseURL}/images/thumbs/${article.thumb}`} />
+            <img className={styles.thumbnail} src={`${import.meta.env.VITE_NEWS_SERVER_URL}/images/thumbs/${article.thumb}`} />
             <div className={styles.main}>
                 <div className={styles.top_container}>
                     <div className={styles.top}>
@@ -46,7 +45,7 @@ const NewsEntry: React.FC<Props> = ({ article }: Props) => {
                                 key={`${data?.avatar}`}
                                 height={24}
                                 alt={`${data?.displayName}'s avatar`}
-                                src={[`${newsBaseURL}/images/avatars/${data?.avatar}`, UnknownUserIcon]}
+                                src={[`${import.meta.env.VITE_NEWS_SERVER_URL}/images/avatars/${data?.avatar}`, UnknownUserIcon]}
                                 style={{ borderRadius: "50%" }}
                             />))
                     }

--- a/src/components/Onboarding/Pages/ComponentsPage.tsx
+++ b/src/components/Onboarding/Pages/ComponentsPage.tsx
@@ -51,7 +51,7 @@ interface Props {
 export const ComponentsPage: React.FC<Props> = ({ profileUrls, setProfileUrls }: Props) => {
     const onboardingIndexQuery = useQuery({
         queryKey: ["OnboardingIndex"],
-        queryFn: async (): Promise<OnboardingIndex> => await fetch("https://releases.yarg.in/profiles/onboarding.json")
+        queryFn: async (): Promise<OnboardingIndex> => await fetch(`${import.meta.env.VITE_RELEASES_SERVER_URL}/profiles/onboarding.json`)
             .then(res => res.json())
     });
 

--- a/src/hooks/useMarketIndex.ts
+++ b/src/hooks/useMarketIndex.ts
@@ -5,7 +5,7 @@ const useMarketIndex = (enabled?: boolean) => {
     return useQuery({
         enabled: enabled,
         queryKey: ["MarketIndex"],
-        queryFn: async (): Promise<MarketplaceIndex> => await fetch("https://releases.yarg.in/profiles/")
+        queryFn: async (): Promise<MarketplaceIndex> => await fetch(`${import.meta.env.VITE_RELEASES_SERVER_URL}/profiles/`)
             .then(res => res.json())
     });
 };

--- a/src/hooks/useNews.ts
+++ b/src/hooks/useNews.ts
@@ -1,4 +1,3 @@
-import { newsBaseURL } from "@app/utils/consts";
 import { useQuery } from "@tanstack/react-query";
 
 export interface ArticleData {
@@ -19,7 +18,7 @@ export const useNews = () => {
     return useQuery({
         queryKey: ["NewsIndex"],
         queryFn: async (): Promise<NewsData> => await fetch(
-            `${newsBaseURL}/index.json`)
+            `${import.meta.env.VITE_NEWS_SERVER_URL}/index.json`)
             .then(res => res.json())
     });
 };

--- a/src/hooks/useNewsArticle.ts
+++ b/src/hooks/useNewsArticle.ts
@@ -1,4 +1,3 @@
-import { newsBaseURL } from "@app/utils/consts";
 import { useQuery } from "@tanstack/react-query";
 
 export interface Article {
@@ -15,7 +14,7 @@ export const useNewsArticle = (md: string) => {
         queryKey: ["NewsArticle", md],
         gcTime: 60 * 60 * 1000,
         queryFn: async () => await fetch(
-            `${newsBaseURL}/articles/${md}.md`)
+            `${import.meta.env.VITE_NEWS_SERVER_URL}/articles/${md}.md`)
             .then(res => res.text())
     });
 };

--- a/src/hooks/useNewsAuthor.ts
+++ b/src/hooks/useNewsAuthor.ts
@@ -1,4 +1,3 @@
-import { newsBaseURL } from "@app/utils/consts";
 import { useQuery } from "@tanstack/react-query";
 
 export interface AuthorData {
@@ -11,7 +10,7 @@ export const useNewsAuthorSettings = (authorId: string) => {
     return {
         queryKey: ["NewsAuthor", authorId],
         queryFn: async (): Promise<AuthorData> => await fetch(
-            `${newsBaseURL}/authors/${authorId}.json`)
+            `${import.meta.env.VITE_NEWS_SERVER_URL}/authors/${authorId}.json`)
             .then(res => res.json())
     };
 };

--- a/src/routes/NewsPage/index.tsx
+++ b/src/routes/NewsPage/index.tsx
@@ -8,7 +8,6 @@ import NewsBadge from "@app/components/NewsSection/NewsBadge";
 import { CSSProperties } from "react";
 import { BackIcon, TimeIcon } from "@app/assets/Icons";
 import { formatDistance } from "date-fns";
-import { newsBaseURL } from "@app/utils/consts";
 import { useQueries } from "@tanstack/react-query";
 import { useNewsAuthorSettings } from "@app/hooks/useNewsAuthor";
 import NewsAuthor from "@app/components/NewsSection/NewsAuthor";
@@ -35,7 +34,7 @@ function NewsPage() {
     if (error) return `An error has occurred: ${error}`;
 
     return <>
-        <div className={styles.header} style={{ "--bannerURL": `url(${newsBaseURL}/images/banners/${articleData?.banner})` } as CSSProperties}>
+        <div className={styles.header} style={{ "--bannerURL": `url(${import.meta.env.VITE_NEWS_SERVER_URL}/images/banners/${articleData?.banner})` } as CSSProperties}>
             <div onClick={() => navigate(-1)} className={styles.header_back}>
                 <BackIcon />
                     RETURN

--- a/src/utils/consts.ts
+++ b/src/utils/consts.ts
@@ -1,1 +1,0 @@
-export const newsBaseURL = "https://raw.githubusercontent.com/YARC-Official/News/master";

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,2 +1,16 @@
 /// <reference types="vite/client" />
 /// <reference types="vite-plugin-svgr/client" />
+
+interface ViteTypeOptions {
+  // By adding this line, you can make the type of ImportMetaEnv strict
+  // to disallow unknown keys.
+  // strictImportMetaEnv: unknown
+}
+
+interface ImportMetaEnv {
+  readonly VITE_RELEASES_SERVER_URL: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -9,6 +9,7 @@ interface ViteTypeOptions {
 
 interface ImportMetaEnv {
   readonly VITE_RELEASES_SERVER_URL: string
+  readonly VITE_NEWS_SERVER_URL: string
 }
 
 interface ImportMeta {


### PR DESCRIPTION
This PR un-hardcodes the URL for https://releases.yarg.in and allows the developer to add their own server by changing the VITE_RELEASES_SERVER_URL env variable

if you want to point the launcher to your own fork of releases.yarg.in, you can do so by creating a `.env.development.local` file with the URL of your fork, like so:
```
VITE_RELEASES_SERVER_URL=https://shadowflower64.github.io/releases.yarg.in/
```