### PR TITLE
Remove LD_LIBRARY_PATH from env variables of child process

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -263,17 +263,17 @@ fn launch_profile(
     path.push(exec_path);
 
     if !use_obs_vkcapture {
-        Command::new(path).args(arguments).spawn().map_err(|e| {
-            format!(
-                "Failed to launch profile! Is the executable installed?\n{:?}",
-                e
-            )
-        })?;
+        Command::new(path)
+            .args(arguments)
+            .env_remove("LD_LIBRARY_PATH")
+            .spawn()
+            .map_err(|e| format!("Failed to launch profile! Is the executable installed?\n{:?}", e))?;
     } else {
         let path_str = path_to_string(path)?;
 
         Command::new("obs-gamecapture")
             .args([path_str].iter().chain(&arguments))
+            .env_remove("LD_LIBRARY_PATH")
             .spawn()
             .map_err(|e| format!("Failed to launch profile! Is the executable installed? Is obs-vkcapture installed and pathed?\n{:?}", e))?;
     }


### PR DESCRIPTION
This fixes the issue of Nightly not being able to be launched from the launcher on Linux on Debian. The issue is described in detail on Discord: https://discord.com/channels/1086048856678084609/1378993508639182968

Essentially, here is the rundown of the issue:
* The AppImage includes some library files. These may be different versions from the system-installed library files.
* The launcher executable within the AppImage is being launched with the LD_LIBRARY_PATH environment variable set to the directory with the bundled libraries. This allows the launcher to use the bundled libs instead of system libs.
* When the YARG executable is launched with the launcher, the spawned process inherits the LD_LIBRARY_PATH environment variable of the launcher.
* This means that some of the libraries that the executable uses are the versions bundled in with the launcher, and some are system-installed libraries. This mix of library versions was causing an instant crash on Vulkan. ..OpenGL was fine for some reason, probably because it happened not to cause any library version conflicts.

This issue affects the official 1.0.2 build of the launcher. Some test builds made on Ubuntu 24 seemed to fix the issue, most likely because the libraries were updated to newer versions, which may be more compatible with Debian(?) So this issue seems like its fixed for now. But, still, without this explicit fix, the issue will most likely reappear in the future, whenever a linux distribution updates, and the libraries will become incompatible again.

The fix in this PR is just to unset the LD_LIBRARY_PATH explicitly when spawning the YARG subprocess. This ensures that the game is not launched with any weird libraries from the AppImage, and instead just uses the system libraries.