### PR TITLE
Fix broken marketplace on Linux (#73)

### DIFF
--- a/src/routes/Marketplace/Marketplace.module.css
+++ b/src/routes/Marketplace/Marketplace.module.css
@@ -141,6 +141,7 @@
 
     min-width: var(--item-width);
     max-width: var(--item-width);
+    height: fit-content;
 
     padding: 12px;
     align-items: center;


### PR DESCRIPTION
This issue fixes #73 by explicitly setting the height of the .profileView button to "fit-content"

Before:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/1439dd93-8162-41fc-851f-51779ee29531" />

After:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/f82926a2-dd3c-428d-b5da-aab8f722a4ae" />
