### PR TITLE
Throw profile installed error if pending tasks when deleting profile

### DIFF
--- a/src/hooks/useProfileState.ts
+++ b/src/hooks/useProfileState.ts
@@ -10,6 +10,7 @@ import { IBaseTask } from "@app/tasks/Processors/base";
 import { invoke } from "@tauri-apps/api/core";
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import QueueStore from "../tasks/queue";
 
 export enum ProfileFolderState {
     Error = 0,
@@ -122,7 +123,7 @@ export const useProfileState = (profileUUID: string): ProfileState => {
                 return;
             }
 
-            if (folderState !== ProfileFolderState.FirstDownload) {
+            if (folderState !== ProfileFolderState.FirstDownload || QueueStore.firstTask()?.activeProfile.uuid === activeProfile.uuid) {
                 createAndShowDialog(UninstallBeforeDeleteDialog);
                 return;
             }

--- a/src/hooks/useProfileState.ts
+++ b/src/hooks/useProfileState.ts
@@ -123,7 +123,8 @@ export const useProfileState = (profileUUID: string): ProfileState => {
                 return;
             }
 
-            if (folderState !== ProfileFolderState.FirstDownload || QueueStore.firstTask()?.activeProfile.uuid === activeProfile.uuid) {
+            if (folderState !== ProfileFolderState.FirstDownload ||
+                QueueStore.findTask(QueueStore.store.getState(), activeProfile.uuid)) {
                 createAndShowDialog(UninstallBeforeDeleteDialog);
                 return;
             }


### PR DESCRIPTION
Fixes #79. 
Taking advantage of the already existing queue system for install and uninstall tasks, the code now checks for any pending tasks with the same profile uuid as the profile being requested for deletion, in the same conditional where it's checked if the game is installed. 
The logic here is that the folder state only changes when the installation is completed, so this condition wasn't enough to prevent profile deletions during installation. I don't see a need for a new error message either because a profile being installed, or in the process of being installed, is pretty much the same thing for this purpose.