### PR TITLE
Fix vertical scrollbar appearing where it shouldn't

### DIFF
--- a/src/routes/Marketplace/Marketplace.module.css
+++ b/src/routes/Marketplace/Marketplace.module.css
@@ -121,6 +121,7 @@
 
     max-width: 100%;
     overflow-x: auto;
+    overflow-y: hidden;
 
     padding: 12px;
 


### PR DESCRIPTION
This PR hides the vertical scrollbar on Linux on collapsed profile lists in the marketplace screen. The scrollbar shouldn't be there and scrolling it has very janky behavior. See the screenshots below for a comparison

## Before
<img width="1326" height="818" alt="Screenshot_20250905_195209" src="https://github.com/user-attachments/assets/8ef96355-ef65-461c-b5d6-1ed7d067f002" />

## After
<img width="1609" height="870" alt="Screenshot_20250905_195850" src="https://github.com/user-attachments/assets/a863cb45-6411-4b87-bc9d-5b204ac1ab25" />

With this PR, most of the Linux UI jank has been removed and the launcher should be much more usable for Linux users now.